### PR TITLE
Aanpassingen LDIF voor ontwikkelomgevingen tbv autorisatie, connects to CDS-VRN/InSpider#5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,19 @@
 	<packaging>jar</packaging>
 	<version>2.3-SNAPSHOT</version>
 
+	<repositories>
+		<repository>
+			<id>geotools-repo</id>
+			<url>http://download.osgeo.org/webdav/geotools/</url>
+			<releases>
+				<updatePolicy>never</updatePolicy>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>	
+	</repositories>
+	
 	<properties>
 		<cds-version>2.3-SNAPSHOT</cds-version>
 		<cds-ipo-version>2.3-SNAPSHOT</cds-ipo-version>

--- a/src/main/vagrant/ldap-ontw.ldif
+++ b/src/main/vagrant/ldap-ontw.ldif
@@ -10,11 +10,23 @@ objectClass: top
 objectClass: organizationalUnit
 ou: Group
 
-dn: cn=beheerder,ou=Group,dc=inspire,dc=idgis,dc=eu
+dn: cn=cds-gebruikers,ou=Group,dc=inspire,dc=idgis,dc=eu
 objectClass: top
 objectClass: groupOfNames
-cn: beheerder
+cn: cds-gebruikers
 member: uid=admin,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=drenthe,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=flevoland,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=friesland,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=gelderland,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=groningen,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=limburg,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=noordbrabant,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=noordholland,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=overijssel,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=utrecht,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=zeeland,ou=People,dc=inspire,dc=idgis,dc=eu
+member: uid=zuidholland,ou=People,dc=inspire,dc=idgis,dc=eu
 
 dn: uid=admin,ou=People,dc=inspire,dc=idgis,dc=eu
 objectClass: top
@@ -26,78 +38,6 @@ sn: admin
 mail: none@none.local
 uid: admin
 userPassword:: e1NIQX0wRFBpS3VOSXJyVm1EOElVQ3V3MWhReE5xWmM9
-
-dn: cn=noordbrabant,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: noordbrabant
-member: uid=noordbrabant,ou=People,dc=inspire,dc=idgis,dc=eu
-
-dn: cn=friesland,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: friesland
-member: uid=friesland,ou=People,dc=inspire,dc=idgis,dc=eu
-
-dn: cn=drenthe,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: drenthe
-member: uid=drenthe,ou=People,dc=inspire,dc=idgis,dc=eu
-
-dn: cn=flevoland,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: flevoland
-member: uid=flevoland,ou=People,dc=inspire,dc=idgis,dc=eu
-
-dn: cn=gelderland,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: gelderland
-member: uid=gelderland,ou=People,dc=inspire,dc=idgis,dc=eu
-
-dn: cn=groningen,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: groningen
-member: uid=groningen,ou=People,dc=inspire,dc=idgis,dc=eu
-
-dn: cn=limburg,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: limburg
-member: uid=limburg,ou=People,dc=inspire,dc=idgis,dc=eu
-
-dn: cn=noordholland,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: noordholland
-member: uid=noordholland,ou=People,dc=inspire,dc=idgis,dc=eu
-
-dn: cn=overijssel,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: overijssel
-member: uid=overijssel,ou=People,dc=inspire,dc=idgis,dc=eu
-
-dn: cn=utrecht,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: utrecht
-member: uid=utrecht,ou=People,dc=inspire,dc=idgis,dc=eu
-
-dn: cn=zeeland,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: zeeland
-member: uid=zeeland,ou=People,dc=inspire,dc=idgis,dc=eu
-
-dn: cn=zuidholland,ou=Group,dc=inspire,dc=idgis,dc=eu
-objectClass: top
-objectClass: groupOfNames
-cn: zuidholland
-member: uid=zuidholland,ou=People,dc=inspire,dc=idgis,dc=eu
 
 dn: uid=drenthe,ou=People,dc=inspire,dc=idgis,dc=eu
 objectClass: top


### PR DESCRIPTION
De LDIF die wordt gebruikt om de ontwikkelomgeving van LDAP te vullen is aangepast zodat deze de LDAP server op de juiste manier vult.